### PR TITLE
5 modify listenonlyloop to separate network connection behavior

### DIFF
--- a/internal/AX25/AX25_test.go
+++ b/internal/AX25/AX25_test.go
@@ -1,6 +1,8 @@
 package AX25
 
 import (
+	"bytes"
+	"fmt"
 	"testing"
 )
 
@@ -88,10 +90,11 @@ func Test_ConvertBytesToAX25_RunsWithoutErrorOnTestFile(t *testing.T) {
 		t.Fatalf(`%v`, err)
 	}
 
-	_, err = ConvertBytesToAX25(ax25_raw)
+	output, err := ConvertBytesToAX25(ax25_raw)
 	if err != nil {
 		t.Fatalf(`%v`, err)
 	}
+	fmt.Printf("%v\n", output)
 
 }
 
@@ -161,7 +164,7 @@ func Test_AX25_frame_TNC2_String(t *testing.T) {
 	src := Callsign{Call: "KK7EWJ", Ssid: 7}
 	dst := Callsign{Call: "N0CALL", Ssid: 2}
 	digi := []Callsign{{Call: "WIDE2", Ssid: 1}, {Call: "RS0ISS", IsCmdOrRpt: true}}
-	result := AX25_frame{Source_addr: src, Dest_addr: dst, Digi_path: digi, Info_field: "foobartest"}.GoString()
+	result := AX25_frame{Source_addr: src, Dest_addr: dst, Digi_path: digi, Info_field: "foobartest"}.String()
 	expected := "KK7EWJ-7>N0CALL-2,WIDE2-1,RS0ISS*:foobartest"
 	if result != expected {
 		t.Errorf("Expected %s but got %s", expected, result)
@@ -189,10 +192,57 @@ func Test_AX25_frame_TNC2_multiple_repeaters_only_star_last_repeater(t *testing.
 	}
 }
 
-func Test_Callsign_GoString(t *testing.T) {
+func Test_Callsign_String(t *testing.T) {
 	call := Callsign{Call: "KK7EWJ", Ssid: 7}
 	expected := "KK7EWJ-7"
-	if call.GoString() != expected {
+	if call.String() != expected {
 		t.Errorf("Expected %s but got %s", expected, call)
+	}
+}
+
+func Test_Callsign_AX25Encode(t *testing.T) {
+	//KK7EWJ-7
+	data := Callsign{Call: "KK7EWJ", Ssid: 7}
+	result := data.AX25Encode(AX25_RESERVED_BITS)
+	expected := []byte{0x96, 0x96, 0x6e, 0x8a, 0xae, 0x94, 0x6e}
+	if !bytes.Equal(result, expected) {
+		t.Errorf("  Result: %x\n", result)
+		t.Errorf("Expected: %x\n", expected)
+	}
+}
+
+func Test_Callsign_AX25Encode_short_call(t *testing.T) {
+	data := Callsign{Call: "WIDE1", Ssid: 1}
+	result := data.AX25Encode(AX25_RESERVED_BITS)
+	expect := []byte{0xae, 0x92, 0x88, 0x8a, 0x62, 0x40, 0x62}
+
+	if !bytes.Equal(result, expect) {
+		t.Errorf("Expect %x, Got %x", expect, result)
+	}
+}
+
+func Test_AX25_frame_Bytes(t *testing.T) {
+	raw, err := readBytesFromFile("./test.ax25")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected, err := StripKISSWrapper(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// KK7EWJ-7>APDR16,WIDE1-1,WIDE2-1:=3707.62N/11337.37W[/A=002735 hiking
+	input := AX25_frame{
+		Dest_addr:   Callsign{Call: "APDR16"},
+		Source_addr: Callsign{Call: "KK7EWJ", Ssid: 7},
+		Digi_path:   []Callsign{{Call: "WIDE1", Ssid: 1}, {Call: "WIDE2", Ssid: 1}},
+		Info_field:  "=3707.62N/11337.37W[/A=002735 hiking",
+	}
+	result := input.Bytes(false)
+
+	if !bytes.Equal(result, expected) {
+		t.Logf("exp: %x \n", expected[14:21]) //
+		t.Logf("res: %x \n", result[14:21])   //
+		t.Error("Do not match")
 	}
 }

--- a/network_aprs.go
+++ b/network_aprs.go
@@ -10,16 +10,51 @@ import (
 	"github.com/fatih/color"
 )
 
+// emulates a KISS server for testing purposes
+func KISSServerEmulator(conn_chan chan net.Conn, input_chan chan []byte) (chan bool, chan error) {
+	done_channel := make(chan bool)
+	err_channel := make(chan error)
+
+	// spin up a goroutine to handle channel inputs
+	go func() {
+		for {
+			select {
+			case <-done_channel:
+				return
+			case conn := <-conn_chan:
+				// spin up a goroutine to send data from the channel to the requestor
+				go func() {
+					for {
+						data, open := <-input_chan
+						if !open {
+							return
+						}
+
+						_, err := conn.Write(data)
+						if err != nil {
+							err_channel <- err
+							return
+						}
+					}
+				}()
+			}
+		}
+	}()
+
+	return done_channel, err_channel
+}
+
 // connects to, and listens to a KISS server. Returns a channel. Meant to run as a goroutine.
 func KISSServerConnector(server string) (chan AX25.AX25_frame, chan error, error) {
-	frame_chan := make(chan AX25.AX25_frame)
-	error_chan := make(chan error)
 
 	conn, err := net.Dial("tcp", server)
 
 	if err != nil {
-		return frame_chan, error_chan, fmt.Errorf("KISSServerConnector: %v", err)
+		return nil, nil, fmt.Errorf("KISSServerConnector: %v", err)
 	}
+
+	frame_chan := make(chan AX25.AX25_frame)
+	error_chan := make(chan error)
 
 	// start the connection listener in a goroutine
 	go func() {

--- a/network_aprs_test.go
+++ b/network_aprs_test.go
@@ -1,11 +1,49 @@
 package main
 
 import (
+	"net"
 	"testing"
+	"time"
 )
 
-func Test_test(t *testing.T) {
-	if 1+1 != 2 {
-		t.Error("Something has gone horribly wrong...")
+func Test_KISSServerConnector_failsOnBadTarget(t *testing.T) {
+
+	srv := "badresolver.kk7ewj.net:0000"
+
+	_, _, err := KISSServerConnector(srv)
+
+	if err != nil {
+		// expected behavior
+		return
+	} else {
+		t.Errorf("Expected an error to throw for bad srv addr, but got none")
 	}
+
+}
+
+func Test_KISSServerConnector_goodConnection(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	defer func() {
+		t.Log("Closing listener")
+		listener.Close()
+	}()
+	srv := listener.Addr().String()
+	t.Log(srv)
+
+	_, error_chan, err := KISSServerConnector(srv)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case err := <-error_chan:
+		t.Fatal(err)
+	case <-time.After(time.Second * 1):
+		return // expected behavior
+	}
+
 }

--- a/network_aprs_test.go
+++ b/network_aprs_test.go
@@ -1,11 +1,56 @@
 package main
 
 import (
+	"bytes"
 	"internal/AX25"
 	"net"
 	"testing"
 	"time"
 )
+
+// emulates a KISS server for testing purposes. Only meant for one connection at a time. Multiple WILL break this.
+func internal_KISSServerEmulator(address string) (string, chan []byte, chan error, error) {
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return "", nil, nil, err
+	}
+
+	input_chan := make(chan []byte)
+	shutdown_chan := make(chan struct{})
+	err_chan := make(chan error)
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				select {
+				case <-shutdown_chan:
+					return
+				default:
+					err_chan <- err
+				}
+			}
+
+			go func() {
+				for {
+					data := &bytes.Buffer{}
+					data.Write([]byte{0xc0, 0x0})
+					data.Write(<-input_chan)
+					data.Write([]byte{0xc0})
+
+					_, err := conn.Write(data.Bytes())
+					if err != nil {
+						err_chan <- err
+						return
+					}
+				}
+			}()
+
+		}
+	}()
+
+	return listener.Addr().String(), input_chan, err_chan, nil
+}
 
 func Test_KISSServerConnector_failsOnBadTarget(t *testing.T) {
 

--- a/network_aprs_test.go
+++ b/network_aprs_test.go
@@ -47,3 +47,25 @@ func Test_KISSServerConnector_goodConnection(t *testing.T) {
 	}
 
 }
+
+// func Test_KISServerConnector_various_inputs(t *testing.T) {
+// 	// set up the fake emulator server
+// 	listener, err := net.Listen("tcp", "127.0.0.1:0")
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	listen_addr := listener.Addr().String()
+// 	data_chan := make(chan []byte)
+// 	conn_chan := make(chan net.Conn)
+
+// 	em_done_chan, em_err_chan := KISSServerEmulator(conn_chan, data_chan)
+
+// 	// set up KISSServerConnector
+// 	ax25_chan, kiss_err_chan, err := KISSServerConnector(listen_addr)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+
+// 	// do stuff
+
+// }


### PR DESCRIPTION
closes #5 
- Adds KISSServerEmulator for internal testing
- Changes ListenOnlyLoop to use channels to allow different types of data sources
- Unit Tests for AX25 and main package
- add Bytes method to AX25 frames to turn them into bytes